### PR TITLE
Fix alt text and cleanup minor CSS

### DIFF
--- a/collection.html
+++ b/collection.html
@@ -158,8 +158,8 @@
       <img src="images/stormen_mugblackback.png" alt="Stormen Black Mug back" class="rounded-lg shadow-md back" />
     </a>
     <a href="https://stormen-shop.fourthwall.com/en-usd/products/stormen-moustache-mug" target="_blank" class="block merch-item min-w-0 w-full">
-      <img src="images/whitemug_back.png" alt="Stormen White Mug front" class="rounded-lg shadow-md front" />
-      <img src="images/whitemug_front.png" alt="Stormen White Mug back" class="rounded-lg shadow-md back" />
+        <img src="images/whitemug_back.png" alt="Stormen White Mug back" class="rounded-lg shadow-md front" />
+        <img src="images/whitemug_front.png" alt="Stormen White Mug front" class="rounded-lg shadow-md back" />
     </a>
     <a href="https://stormen-shop.fourthwall.com/en-usd/products/octane-hype-holo-sticker" target="_blank" class="block merch-item min-w-0 w-full">
       <img src="images/hype_sticker.png" alt="Stormen Hype Sticker front" class="rounded-lg shadow-md front" />

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <style>
     body { font-family: 'Roboto Condensed', sans-serif; }
     
-    .burger-line { display: block; width: 48px; height: 2px; margin: 6px 0; background: #ffffff;; transition: transform 0.3s, background-color 0.3s; }
+    .burger-line { display: block; width: 48px; height: 2px; margin: 6px 0; background: #ffffff; transition: transform 0.3s, background-color 0.3s; }
 /* default state */
 #siteHeader {
   background: transparent;
@@ -67,7 +67,7 @@
     #backdrop { transition: opacity 0.3s ease-in-out; }
     #sidePanel a {
       display: inline-flex;
-      align-items: center   align-items: center;
+      align-items: center;
     }
     #sidePanel a span {
       position: relative;
@@ -180,7 +180,6 @@
       poster="images/video-poster.jpg"
     >
       <source src="media/chasethestormer.mp4" type="video/mp4">
-      <source src="media/chasethestorms.mp4" type="video/mp4">
       Your browser does not support the video tag.
     </video>
     <div class="absolute inset-0 bg-black bg-opacity-0 z-20"></div>
@@ -217,8 +216,8 @@
       <img src="images/stormen_mugblackback.png" alt="Stormen Black Mug back" class="rounded-lg shadow-md back" />
     </a>
     <a href="https://stormen-shop.fourthwall.com/en-usd/products/stormen-moustache-mug" target="_blank" class="block merch-item min-w-0 w-full">
-      <img src="images/whitemug_back.png" alt="Stormen White Mug front" class="rounded-lg shadow-md front" />
-      <img src="images/whitemug_front.png" alt="Stormen White Mug back" class="rounded-lg shadow-md back" />
+      <img src="images/whitemug_back.png" alt="Stormen White Mug back" class="rounded-lg shadow-md front" />
+      <img src="images/whitemug_front.png" alt="Stormen White Mug front" class="rounded-lg shadow-md back" />
     </a>
     <a href="https://stormen-shop.fourthwall.com/en-usd/products/octane-hype-holo-sticker" target="_blank" class="block merch-item min-w-0 w-full">
       <img src="images/hype_sticker.png" alt="Stormen Hype Sticker front" class="rounded-lg shadow-md front" />


### PR DESCRIPTION
## Summary
- fix reversed alt text for white mug images
- remove nonexistent video source
- clean up small CSS typos

## Testing
- `tidy -q -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdf20e24883279297fecdeb00cd6b