### PR TITLE
Add dark mode toggle

### DIFF
--- a/collection.html
+++ b/collection.html
@@ -64,6 +64,27 @@
     .dot-active { background: #000000; }
     .social-link img { transition: filter 0.3s ease; }
     .social-link:hover img { filter: brightness(0) invert(0.4); }
+    #themeToggle { z-index: 60; }
+    body.dark {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark #sidePanel {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark footer {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark #siteHeader.scrolled {
+      background-color: #1a202c;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+    }
+    body.dark #siteHeader .burger-line {
+      background-color: #ffffff !important;
+    }
+    body.dark #sidePanel a span::after { background-color: #ffffff; }
   </style>
 </head>
 <body class="bg-gray-100 text-gray-900 min-h-screen flex flex-col">
@@ -79,6 +100,9 @@
     <a href="/" class="mx-auto h-36 flex items-center justify-center">
       <img src="images/logo_yellow.png" alt="Stormen yellow logo" class="h-36" />
     </a>
+    <button id="themeToggle" class="absolute right-4 top-1/2 transform -translate-y-1/2 p-3 focus:outline-none" aria-label="Toggle dark mode">
+      <i data-feather="moon"></i>
+    </button>
   </header>
 
   <!-- Side Panel -->
@@ -222,6 +246,13 @@
       const panel = document.getElementById('sidePanel');
       const backdrop = document.getElementById('backdrop');
       const hdr = document.getElementById('siteHeader');
+      const themeToggle = document.getElementById('themeToggle');
+      const storedTheme = localStorage.getItem('theme');
+      if (storedTheme === 'dark') {
+        document.body.classList.add('dark');
+        themeToggle.setAttribute('data-feather', 'sun');
+      }
+      if (typeof feather !== 'undefined') feather.replace();
       if (!openMenuBtn || !closeMenuBtn || !panel || !backdrop || !hdr) {
         console.error('One or more required elements not found:');
         if (!openMenuBtn) console.error('openMenuBtn not found');
@@ -277,6 +308,12 @@
           console.log('Clicked outside panel, closing');
           closePanel();
         }
+      });
+      themeToggle.addEventListener('click', () => {
+        const isDark = document.body.classList.toggle('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        themeToggle.setAttribute('data-feather', isDark ? 'sun' : 'moon');
+        if (typeof feather !== 'undefined') feather.replace();
       });
       window.addEventListener('scroll', () => {
         const scrolled = window.scrollY > 10;

--- a/index.html
+++ b/index.html
@@ -108,6 +108,27 @@
     .dot-active { background: #000000; }
     .social-link img { transition: filter 0.3s ease; }
     .social-link:hover img { filter: brightness(0) invert(0.4); }
+    #themeToggle { z-index: 60; }
+    body.dark {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark #sidePanel {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark footer {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark #siteHeader.scrolled {
+      background-color: #1a202c;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+    }
+    body.dark #siteHeader .burger-line {
+      background-color: #ffffff !important;
+    }
+    body.dark #sidePanel a span::after { background-color: #ffffff; }
   </style>
 </head>
 <body class="bg-gray-100 text-gray-900 min-h-screen flex flex-col">
@@ -124,6 +145,9 @@
       <img src="images/logo_white.png" alt="Stormen white logo" class="h-36 logo-white transition-opacity duration-300" />
       <img src="images/logo_yellow.png" alt="Stormen yellow logo" class="h-36 logo-black opacity-0 absolute inset-0 transition-opacity duration-300" />
     </a>
+    <button id="themeToggle" class="absolute right-4 top-1/2 transform -translate-y-1/2 p-3 focus:outline-none" aria-label="Toggle dark mode">
+      <i data-feather="moon"></i>
+    </button>
   </header>
 
   <!-- Side Panel -->
@@ -283,6 +307,13 @@
       const panel = document.getElementById('sidePanel');
       const backdrop = document.getElementById('backdrop');
       const hdr = document.getElementById('siteHeader');
+      const themeToggle = document.getElementById('themeToggle');
+      const storedTheme = localStorage.getItem('theme');
+      if (storedTheme === 'dark') {
+        document.body.classList.add('dark');
+        themeToggle.setAttribute('data-feather', 'sun');
+      }
+      if (typeof feather !== 'undefined') feather.replace();
       if (!openMenuBtn || !closeMenuBtn || !panel || !backdrop || !hdr) {
         console.error('One or more required elements not found:');
         if (!openMenuBtn) console.error('openMenuBtn not found');
@@ -338,6 +369,12 @@
           console.log('Clicked outside panel, closing');
           closePanel();
         }
+      });
+      themeToggle.addEventListener('click', () => {
+        const isDark = document.body.classList.toggle('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        themeToggle.setAttribute('data-feather', isDark ? 'sun' : 'moon');
+        if (typeof feather !== 'undefined') feather.replace();
       });
       window.addEventListener('scroll', () => {
   const hdr = document.getElementById('siteHeader');

--- a/social.html
+++ b/social.html
@@ -62,6 +62,27 @@
       font-family: 'Roboto Mono', monospace;
       color: #000000;
     }
+    #themeToggle { z-index: 60; }
+    body.dark {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark #sidePanel {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark footer {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark #siteHeader.scrolled {
+      background-color: #1a202c;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+    }
+    body.dark #siteHeader .burger-line {
+      background-color: #ffffff !important;
+    }
+    body.dark #sidePanel a span::after { background-color: #ffffff; }
   </style>
 </head>
 <body class="bg-gray-100 text-gray-900 min-h-screen flex flex-col">
@@ -78,6 +99,9 @@
       <img src="images/logo_yellow.png" alt="Stormen white logo" class="h-36 logo-white transition-opacity duration-300" />
       <img src="images/logo_yellow.png" alt="Stormen yellow logo" class="h-36 logo-black opacity-0 absolute inset-0 transition-opacity duration-300" />
     </a>
+    <button id="themeToggle" class="absolute right-4 top-1/2 transform -translate-y-1/2 p-3 focus:outline-none" aria-label="Toggle dark mode">
+      <i data-feather="moon"></i>
+    </button>
   </header>
 
   <!-- Side Panel -->
@@ -176,6 +200,13 @@
       const panel = document.getElementById('sidePanel');
       const backdrop = document.getElementById('backdrop');
       const hdr = document.getElementById('siteHeader');
+      const themeToggle = document.getElementById('themeToggle');
+      const storedTheme = localStorage.getItem('theme');
+      if (storedTheme === 'dark') {
+        document.body.classList.add('dark');
+        themeToggle.setAttribute('data-feather', 'sun');
+      }
+      if (typeof feather !== 'undefined') feather.replace();
       if (!openMenuBtn || !closeMenuBtn || !panel || !backdrop || !hdr) {
         console.error('One or more required elements not found:');
         if (!openMenuBtn) console.error('openMenuBtn not found');
@@ -231,6 +262,12 @@
           console.log('Clicked outside panel, closing');
           closePanel();
         }
+      });
+      themeToggle.addEventListener('click', () => {
+        const isDark = document.body.classList.toggle('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        themeToggle.setAttribute('data-feather', isDark ? 'sun' : 'moon');
+        if (typeof feather !== 'undefined') feather.replace();
       });
       window.addEventListener('scroll', () => {
         const lines = hdr.querySelectorAll('.burger-line');

--- a/stormen.html
+++ b/stormen.html
@@ -82,6 +82,27 @@
     .watch-button:hover span::after {
       width: 100%;
     }
+    #themeToggle { z-index: 60; }
+    body.dark {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark #sidePanel {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark footer {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark #siteHeader.scrolled {
+      background-color: #1a202c;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+    }
+    body.dark #siteHeader .burger-line {
+      background-color: #ffffff !important;
+    }
+    body.dark #sidePanel a span::after { background-color: #ffffff; }
   </style>
 </head>
 <body class="bg-gray-100 text-gray-900 min-h-screen flex flex-col">
@@ -98,6 +119,9 @@
       <img src="images/logo_yellow.png" alt="Stormen white logo" class="h-36 logo-white transition-opacity duration-300" />
       <img src="images/logo_yellow.png" alt="Stormen yellow logo" class="h-36 logo-black opacity-0 absolute inset-0 transition-opacity duration-300" />
     </a>
+    <button id="themeToggle" class="absolute right-4 top-1/2 transform -translate-y-1/2 p-3 focus:outline-none" aria-label="Toggle dark mode">
+      <i data-feather="moon"></i>
+    </button>
   </header>
 
   <!-- Side Panel -->
@@ -224,6 +248,13 @@
       const panel = document.getElementById('sidePanel');
       const backdrop = document.getElementById('backdrop');
       const hdr = document.getElementById('siteHeader');
+      const themeToggle = document.getElementById('themeToggle');
+      const storedTheme = localStorage.getItem('theme');
+      if (storedTheme === 'dark') {
+        document.body.classList.add('dark');
+        themeToggle.setAttribute('data-feather', 'sun');
+      }
+      if (typeof feather !== 'undefined') feather.replace();
       if (!openMenuBtn || !closeMenuBtn || !panel || !backdrop || !hdr) {
         console.error('One or more required elements not found:');
         if (!openMenuBtn) console.error('openMenuBtn not found');
@@ -279,6 +310,12 @@
           console.log('Clicked outside panel, closing');
           closePanel();
         }
+      });
+      themeToggle.addEventListener('click', () => {
+        const isDark = document.body.classList.toggle('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        themeToggle.setAttribute('data-feather', isDark ? 'sun' : 'moon');
+        if (typeof feather !== 'undefined') feather.replace();
       });
       window.addEventListener('scroll', () => {
         const lines = hdr.querySelectorAll('.burger-line');

--- a/watch.html
+++ b/watch.html
@@ -99,6 +99,27 @@
     .watch-link:hover span::after {
       width: 100%;
     }
+    #themeToggle { z-index: 60; }
+    body.dark {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark #sidePanel {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark footer {
+      background-color: #1a202c;
+      color: #f7fafc;
+    }
+    body.dark #siteHeader.scrolled {
+      background-color: #1a202c;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+    }
+    body.dark #siteHeader .burger-line {
+      background-color: #ffffff !important;
+    }
+    body.dark #sidePanel a span::after { background-color: #ffffff; }
   </style>
 </head>
 <body class="bg-gray-100 text-gray-900 min-h-screen flex flex-col">
@@ -114,6 +135,9 @@
     <a href="/" class="mx-auto h-36 flex items-center justify-center">
       <img src="images/logo_yellow.png" alt="Stormen yellow logo" class="h-36" />
     </a>
+    <button id="themeToggle" class="absolute right-4 top-1/2 transform -translate-y-1/2 p-3 focus:outline-none" aria-label="Toggle dark mode">
+      <i data-feather="moon"></i>
+    </button>
   </header>
 
   <!-- Side Panel -->
@@ -230,6 +254,13 @@
       const panel = document.getElementById('sidePanel');
       const backdrop = document.getElementById('backdrop');
       const hdr = document.getElementById('siteHeader');
+      const themeToggle = document.getElementById('themeToggle');
+      const storedTheme = localStorage.getItem('theme');
+      if (storedTheme === 'dark') {
+        document.body.classList.add('dark');
+        themeToggle.setAttribute('data-feather', 'sun');
+      }
+      if (typeof feather !== 'undefined') feather.replace();
       if (!openMenuBtn || !closeMenuBtn || !panel || !backdrop || !hdr) {
         console.error('One or more required elements not found:');
         if (!openMenuBtn) console.error('openMenuBtn not found');
@@ -285,6 +316,12 @@
           console.log('Clicked outside panel, closing');
           closePanel();
         }
+      });
+      themeToggle.addEventListener('click', () => {
+        const isDark = document.body.classList.toggle('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        themeToggle.setAttribute('data-feather', isDark ? 'sun' : 'moon');
+        if (typeof feather !== 'undefined') feather.replace();
       });
       window.addEventListener('scroll', () => {
         const scrolled = window.scrollY > 10;


### PR DESCRIPTION
## Summary
- add a dark mode toggle button in site header
- implement dark mode styles and persistence across all pages

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fe285fc6c83278f74b0012165d12b